### PR TITLE
Fix comment level in Commentary section

### DIFF
--- a/abs-mode.el
+++ b/abs-mode.el
@@ -22,10 +22,10 @@
 
 ;;; Commentary:
 
-;;; A major mode for editing files for the modeling language Abs.
-;;;
-;;; Documentation for the Abs language is at http://docs.abs-models.org/.
-;;;
+;; A major mode for editing files for the modeling language Abs.
+;;
+;; Documentation for the Abs language is at http://docs.abs-models.org/.
+;;
 
 (require 'compile)
 (require 'custom)


### PR DESCRIPTION
`;;;` denotes sections, so this text would not have been correctly parsed out as being the body of the Commentary section.